### PR TITLE
Add atomic replace_document for safe re-indexing

### DIFF
--- a/core/application/indexing/use_case.py
+++ b/core/application/indexing/use_case.py
@@ -49,12 +49,8 @@ class IndexMarkdownUseCase:
             )
             for chunk, embedding in zip(chunks, embeddings, strict=True)
         ]
-        self._section_source.delete_document(doc_id)
-        self._vector_store.delete_document(doc_id)
-        if self._lexical_store is not None:
-            self._lexical_store.delete_document(doc_id)
-        self._section_source.store_document(document)
-        self._vector_store.add(records)
+        self._vector_store.replace_document(doc_id, records)
+        self._section_source.replace_document(document)
         if self._lexical_store is not None:
             self._lexical_store.index_document(
                 doc_id=doc_id,

--- a/core/application/ports/section_source.py
+++ b/core/application/ports/section_source.py
@@ -9,6 +9,9 @@ class SectionSourcePort(Protocol):
     def store_document(self, document: Document) -> None:
         """Persist all node sections for later pointer fetch."""
 
+    def replace_document(self, document: Document) -> None:
+        """Atomically replace all sections for a document."""
+
     def delete_document(self, doc_id: str) -> None:
         """Remove persisted sections for a document before replacement indexing."""
 

--- a/core/application/ports/vector_store.py
+++ b/core/application/ports/vector_store.py
@@ -9,6 +9,9 @@ class VectorStorePort(Protocol):
     def add(self, records: list[VectorRecord]) -> None:
         """Add embedded chunks to the vector index."""
 
+    def replace_document(self, doc_id: str, records: list[VectorRecord]) -> None:
+        """Atomically replace all vectors for a document."""
+
     def delete_document(self, doc_id: str) -> None:
         """Remove all vectors for a document before replacement indexing."""
 

--- a/core/infrastructure/persistence/chroma_vector_store.py
+++ b/core/infrastructure/persistence/chroma_vector_store.py
@@ -39,6 +39,10 @@ class ChromaVectorStore(VectorStorePort):
             ],
         )
 
+    def replace_document(self, doc_id: str, records: list[VectorRecord]) -> None:
+        self.delete_document(doc_id)
+        self.add(records)
+
     def delete_document(self, doc_id: str) -> None:
         self._collection.delete(where={"doc_id": doc_id})
 

--- a/core/infrastructure/persistence/faiss_vector_store.py
+++ b/core/infrastructure/persistence/faiss_vector_store.py
@@ -62,6 +62,42 @@ class FaissVectorStore(VectorStorePort):
         self._records.extend(normalized_records)
         self._save()
 
+    def replace_document(self, doc_id: str, records: list[VectorRecord]) -> None:
+        for record in records:
+            if len(record.embedding) != self._dimension:
+                raise ValueError(
+                    "Embedding dimension mismatch: "
+                    f"expected {self._dimension}, got {len(record.embedding)}"
+                )
+        normalized_records = [
+            VectorRecord(
+                doc_id=record.doc_id,
+                node_id=record.node_id,
+                chunk_id=record.chunk_id,
+                embedding=normalize_vector(record.embedding),
+                text=record.text,
+                breadcrumb=record.breadcrumb,
+            )
+            for record in records
+        ]
+        original_records = list(self._records)
+        original_index = self._index
+        original_fallback_records = list(self._fallback._records)
+        try:
+            self._records = [record for record in self._records if record.doc_id != doc_id]
+            self._records.extend(normalized_records)
+            if self._index is None:
+                self._fallback.delete_document(doc_id)
+                self._fallback.add(normalized_records)
+            else:
+                self._rebuild_index()
+            self._save()
+        except Exception:
+            self._records = original_records
+            self._index = original_index
+            self._fallback._records = original_fallback_records
+            raise
+
     def delete_document(self, doc_id: str) -> None:
         if self._index is None:
             self._records = [record for record in self._records if record.doc_id != doc_id]

--- a/core/infrastructure/persistence/in_memory_section_store.py
+++ b/core/infrastructure/persistence/in_memory_section_store.py
@@ -9,32 +9,19 @@ class InMemorySectionStore(SectionSourcePort):
         self._sections: dict[tuple[str, str], Section] = {}
 
     def store_document(self, document: Document) -> None:
-        nodes = list(document.nodes)
-        for index, node in enumerate(nodes):
-            descendants = [
-                candidate
-                for candidate in nodes[index + 1 :]
-                if candidate.level > node.level
-                and candidate.breadcrumb[: len(node.breadcrumb)] == node.breadcrumb
-            ]
-            descendant_text = [candidate.section_text for candidate in descendants]
-            section_text = "\n\n".join([node.section_text, *descendant_text]).strip()
+        self.replace_document(document)
 
-            end_char = (
-                max(d.end_char for d in descendants if d.end_char is not None)
-                if descendants
-                else node.end_char
-            )
-
-            self._sections[(document.doc_id, node.node_id)] = Section(
-                doc_id=document.doc_id,
-                node_id=node.node_id,
-                breadcrumb=node.breadcrumb,
-                text=section_text,
-                citation=node.citation,
-                start_offset=node.start_char,
-                end_offset=end_char,
-            )
+    def replace_document(self, document: Document) -> None:
+        original_sections = dict(self._sections)
+        try:
+            new_sections = self._build_sections(document)
+            self._sections = {
+                key: section for key, section in self._sections.items() if key[0] != document.doc_id
+            }
+            self._sections.update(new_sections)
+        except Exception:
+            self._sections = original_sections
+            raise
 
     def delete_document(self, doc_id: str) -> None:
         self._sections = {
@@ -52,3 +39,33 @@ class InMemorySectionStore(SectionSourcePort):
         for doc_id, _ in self._sections:
             counts[doc_id] = counts.get(doc_id, 0) + 1
         return counts
+
+    def _build_sections(self, document: Document) -> dict[tuple[str, str], Section]:
+        sections: dict[tuple[str, str], Section] = {}
+        nodes = list(document.nodes)
+        for index, node in enumerate(nodes):
+            descendants = [
+                candidate
+                for candidate in nodes[index + 1 :]
+                if candidate.level > node.level
+                and candidate.breadcrumb[: len(node.breadcrumb)] == node.breadcrumb
+            ]
+            descendant_text = [candidate.section_text for candidate in descendants]
+            section_text = "\n\n".join([node.section_text, *descendant_text]).strip()
+
+            end_char = (
+                max(d.end_char for d in descendants if d.end_char is not None)
+                if descendants
+                else node.end_char
+            )
+
+            sections[(document.doc_id, node.node_id)] = Section(
+                doc_id=document.doc_id,
+                node_id=node.node_id,
+                breadcrumb=node.breadcrumb,
+                text=section_text,
+                citation=node.citation,
+                start_offset=node.start_char,
+                end_offset=end_char,
+            )
+        return sections

--- a/core/infrastructure/persistence/in_memory_vector_store.py
+++ b/core/infrastructure/persistence/in_memory_vector_store.py
@@ -13,6 +13,10 @@ class InMemoryVectorStore(VectorStorePort):
     def add(self, records: list[VectorRecord]) -> None:
         self._records.extend(records)
 
+    def replace_document(self, doc_id: str, records: list[VectorRecord]) -> None:
+        self._records = [record for record in self._records if record.doc_id != doc_id]
+        self._records.extend(records)
+
     def delete_document(self, doc_id: str) -> None:
         self._records = [record for record in self._records if record.doc_id != doc_id]
 

--- a/core/infrastructure/persistence/json_section_store.py
+++ b/core/infrastructure/persistence/json_section_store.py
@@ -14,33 +14,20 @@ class JsonSectionStore(SectionSourcePort):
         self._load()
 
     def store_document(self, document: Document) -> None:
-        nodes = list(document.nodes)
-        for index, node in enumerate(nodes):
-            descendants = [
-                candidate
-                for candidate in nodes[index + 1 :]
-                if candidate.level > node.level
-                and candidate.breadcrumb[: len(node.breadcrumb)] == node.breadcrumb
-            ]
-            descendant_text = [candidate.section_text for candidate in descendants]
-            section_text = "\n\n".join([node.section_text, *descendant_text]).strip()
+        self.replace_document(document)
 
-            end_char = (
-                max(d.end_char for d in descendants if d.end_char is not None)
-                if descendants
-                else node.end_char
-            )
-
-            self._sections[(document.doc_id, node.node_id)] = Section(
-                doc_id=document.doc_id,
-                node_id=node.node_id,
-                breadcrumb=node.breadcrumb,
-                text=section_text,
-                citation=node.citation,
-                start_offset=node.start_char,
-                end_offset=end_char,
-            )
-        self._save()
+    def replace_document(self, document: Document) -> None:
+        original_sections = dict(self._sections)
+        try:
+            new_sections = self._build_sections(document)
+            self._sections = {
+                key: section for key, section in self._sections.items() if key[0] != document.doc_id
+            }
+            self._sections.update(new_sections)
+            self._save()
+        except Exception:
+            self._sections = original_sections
+            raise
 
     def delete_document(self, doc_id: str) -> None:
         self._sections = {
@@ -92,3 +79,33 @@ class JsonSectionStore(SectionSourcePort):
             for section in self._sections.values()
         ]
         self._path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    def _build_sections(self, document: Document) -> dict[tuple[str, str], Section]:
+        sections: dict[tuple[str, str], Section] = {}
+        nodes = list(document.nodes)
+        for index, node in enumerate(nodes):
+            descendants = [
+                candidate
+                for candidate in nodes[index + 1 :]
+                if candidate.level > node.level
+                and candidate.breadcrumb[: len(node.breadcrumb)] == node.breadcrumb
+            ]
+            descendant_text = [candidate.section_text for candidate in descendants]
+            section_text = "\n\n".join([node.section_text, *descendant_text]).strip()
+
+            end_char = (
+                max(d.end_char for d in descendants if d.end_char is not None)
+                if descendants
+                else node.end_char
+            )
+
+            sections[(document.doc_id, node.node_id)] = Section(
+                doc_id=document.doc_id,
+                node_id=node.node_id,
+                breadcrumb=node.breadcrumb,
+                text=section_text,
+                citation=node.citation,
+                start_offset=node.start_char,
+                end_offset=end_char,
+            )
+        return sections

--- a/tests/test_indexing_and_query.py
+++ b/tests/test_indexing_and_query.py
@@ -7,7 +7,8 @@ from core.application.indexing.use_case import IndexMarkdownUseCase
 from core.application.ports.embeddings import EmbedderPort
 from core.application.ports.llm import LlmPort
 from core.application.query.use_case import QueryUseCase
-from core.domain.models import Section
+from core.domain.models import Section, VectorRecord
+from core.infrastructure.persistence.faiss_vector_store import FaissVectorStore
 from core.infrastructure.persistence.in_memory_section_store import (
     InMemorySectionStore,
 )
@@ -266,3 +267,66 @@ def test_section_without_offset_metadata_serializes_successfully(tmp_path) -> No
     assert section.citation is not None
     assert section.start_offset == 0
     assert section.end_offset == len("plain text without headings")
+
+
+def test_reindex_preserves_existing_vectors_when_replace_fails(tmp_path, monkeypatch) -> None:
+    index_path = tmp_path / "vectors.faiss"
+    vector_store = FaissVectorStore(dimension=1, index_path=index_path)
+    section_store = InMemorySectionStore()
+    use_case = IndexMarkdownUseCase(
+        parser=MarkdownSkeletonParser(),
+        chunker=StructureGuidedChunker(),
+        embedder=KeywordEmbedder(),
+        vector_store=vector_store,
+        section_source=section_store,
+    )
+    use_case.execute(
+        doc_id="manual",
+        markdown="# Intro\nWelcome\n\n## Install\nInstall with uv",
+    )
+    original_count = vector_store.count()
+
+    def fail_save(_self) -> None:
+        raise OSError("simulated persistence failure")
+
+    monkeypatch.setattr(FaissVectorStore, "_save", fail_save)
+
+    with pytest.raises(OSError, match="simulated persistence failure"):
+        use_case.execute(doc_id="manual", markdown="# Query\nAsk questions")
+
+    assert vector_store.count() == original_count
+    assert section_store.get_section("manual", "manual:n2").text == "## Install\nInstall with uv"
+
+
+class FailOnReplaceVectorStore(InMemoryVectorStore):
+    def __init__(self) -> None:
+        super().__init__()
+        self.fail_on_replace = False
+
+    def replace_document(self, doc_id: str, records: list[VectorRecord]) -> None:
+        if self.fail_on_replace:
+            raise RuntimeError("simulated replace failure")
+        super().replace_document(doc_id, records)
+
+
+def test_reindex_preserves_existing_vectors_when_in_memory_replace_fails() -> None:
+    vector_store = FailOnReplaceVectorStore()
+    section_store = InMemorySectionStore()
+    use_case = IndexMarkdownUseCase(
+        parser=MarkdownSkeletonParser(),
+        chunker=StructureGuidedChunker(),
+        embedder=KeywordEmbedder(),
+        vector_store=vector_store,
+        section_source=section_store,
+    )
+    use_case.execute(
+        doc_id="manual",
+        markdown="# Intro\nWelcome\n\n## Install\nInstall with uv",
+    )
+    vector_store.fail_on_replace = True
+
+    with pytest.raises(RuntimeError, match="simulated replace failure"):
+        use_case.execute(doc_id="manual", markdown="# Query\nAsk questions")
+
+    assert vector_store.count() == 2
+    assert section_store.get_section("manual", "manual:n2").text == "## Install\nInstall with uv"


### PR DESCRIPTION
## Summary
- Introducerer `replace_document` på vector- og section store-porter for atomisk re-indeksering
- Rollback ved persist-feil (Faiss, JsonSectionStore) slik at eksisterende indeks bevares
- Vektor lagres før seksjon for å unngå inkonsistent tilstand ved feil

## Test plan
- [ ] `uv run pytest tests/test_indexing_and_query.py tests/test_vector_store.py -v`
- [ ] Re-indekser samme `doc_id` og verifiser at gammelt innhold erstattes
- [ ] Verifiser at simulert persist-feil ikke sletter eksisterende indeks


Made with [Cursor](https://cursor.com)