### PR TITLE
Use RRF for hybrid search and improve score handling

### DIFF
--- a/app/container.py
+++ b/app/container.py
@@ -50,7 +50,19 @@ class AppContainer:
             errors.append(str(exc))
         if self._embedding_probe_error is not None:
             errors.append(self._embedding_probe_error)
+        if self.settings.enable_hybrid_search:
+            errors.extend(self._hybrid_search_config_errors())
         return errors
+
+    def _hybrid_search_config_errors(self) -> list[str]:
+        import importlib.util
+
+        if importlib.util.find_spec("rank_bm25") is None:
+            return [
+                "ENABLE_HYBRID_SEARCH is true but rank-bm25 is not installed. "
+                "Install with: uv sync --extra hybrid"
+            ]
+        return []
 
     @cached_property
     def embedder(self):

--- a/core/application/query/use_case.py
+++ b/core/application/query/use_case.py
@@ -192,15 +192,27 @@ class QueryUseCase:
         self,
         vector_hits: list[SearchHit],
         lexical_hits: list[SearchHit],
+        *,
+        rrf_k: int = 60,
     ) -> list[SearchHit]:
-        # Vector cosine scores and BM25 scores use different scales; keep the higher raw score.
-        merged: dict[tuple[str, str], SearchHit] = {}
-        for hit in vector_hits + lexical_hits:
+        # Reciprocal Rank Fusion avoids comparing incompatible raw score scales.
+        rrf_scores: dict[tuple[str, str], float] = {}
+        hit_by_key: dict[tuple[str, str], SearchHit] = {}
+
+        for rank, hit in enumerate(vector_hits, start=1):
             key = (hit.record.doc_id, hit.record.node_id)
-            existing = merged.get(key)
-            if existing is None or hit.score > existing.score:
-                merged[key] = hit
-        return sorted(merged.values(), key=lambda item: item.score, reverse=True)
+            rrf_scores[key] = rrf_scores.get(key, 0.0) + 1.0 / (rrf_k + rank)
+            hit_by_key.setdefault(key, hit)
+
+        for rank, hit in enumerate(lexical_hits, start=1):
+            key = (hit.record.doc_id, hit.record.node_id)
+            rrf_scores[key] = rrf_scores.get(key, 0.0) + 1.0 / (rrf_k + rank)
+            hit_by_key.setdefault(key, hit)
+
+        return [
+            SearchHit(record=hit_by_key[key].record, score=score)
+            for key, score in sorted(rrf_scores.items(), key=lambda item: item[1], reverse=True)
+        ]
 
     def _dedupe_nodes(self, hits: list[SearchHit]) -> list[SearchHit]:
         seen: set[tuple[str, str]] = set()

--- a/core/infrastructure/persistence/chroma_vector_store.py
+++ b/core/infrastructure/persistence/chroma_vector_store.py
@@ -131,7 +131,7 @@ class ChromaVectorStore(VectorStorePort):
                             else ()
                         ),
                     ),
-                    score=1.0 - float(distance),
+                    score=max(0.0, min(1.0, 1.0 - float(distance))),
                 )
             )
         return hits

--- a/tests/test_chroma_vector_store.py
+++ b/tests/test_chroma_vector_store.py
@@ -99,6 +99,35 @@ def test_chroma_vector_store_deletes_by_doc_id_and_maps_search_hits() -> None:
     ]
 
 
+def test_chroma_vector_store_clamps_negative_similarity_scores() -> None:
+    collection = FakeCollection()
+
+    def query_with_large_distance(**kwargs) -> dict[str, object]:
+        return {
+            "ids": [["doc:n1:c1"]],
+            "distances": [[1.5]],
+            "documents": [["chunk text"]],
+            "metadatas": [
+                [
+                    {
+                        "doc_id": "doc",
+                        "node_id": "doc:n1",
+                        "chunk_id": "doc:n1:c1",
+                        "breadcrumb": "Root",
+                    }
+                ]
+            ],
+            "embeddings": [[[1.0, 0.0]]],
+        }
+
+    collection.query = query_with_large_distance  # type: ignore[method-assign]
+    store = ChromaVectorStore(collection=collection)
+
+    hits = store.search([1.0, 0.0], limit=1)
+
+    assert hits[0].score == 0.0
+
+
 def test_chroma_vector_store_count_and_doc_ids() -> None:
     collection = FakeCollection()
     store = ChromaVectorStore(collection=collection)

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -1,7 +1,9 @@
 import pytest
 
 from app.container import AppContainer
+from core.application.query.use_case import QueryUseCase
 from core.config.settings import Settings
+from core.domain.models import SearchHit, VectorRecord
 
 
 def test_hybrid_search_combines_vector_and_lexical(tmp_path) -> None:
@@ -24,3 +26,86 @@ def test_hybrid_search_combines_vector_and_lexical(tmp_path) -> None:
 
     assert response.sources
     assert response.sources[0].node_id == "manual:n2"
+
+
+def test_merge_hits_uses_reciprocal_rank_fusion() -> None:
+    use_case = QueryUseCase(
+        embedder=None,  # type: ignore[arg-type]
+        vector_store=None,  # type: ignore[arg-type]
+        section_source=None,  # type: ignore[arg-type]
+        synthesis_llm=None,
+        reranker_llm=None,
+        enable_llm_reranker=False,
+    )
+    vector_hits = [
+        SearchHit(
+            record=VectorRecord(
+                doc_id="doc",
+                node_id="a",
+                chunk_id="a:c1",
+                embedding=(1.0,),
+                text="alpha",
+                breadcrumb=("A",),
+            ),
+            score=0.9,
+        ),
+        SearchHit(
+            record=VectorRecord(
+                doc_id="doc",
+                node_id="b",
+                chunk_id="b:c1",
+                embedding=(0.5,),
+                text="beta",
+                breadcrumb=("B",),
+            ),
+            score=0.1,
+        ),
+    ]
+    lexical_hits = [
+        SearchHit(
+            record=VectorRecord(
+                doc_id="doc",
+                node_id="b",
+                chunk_id="b:c1",
+                embedding=(),
+                text="beta",
+                breadcrumb=("B",),
+            ),
+            score=42.0,
+        ),
+        SearchHit(
+            record=VectorRecord(
+                doc_id="doc",
+                node_id="c",
+                chunk_id="c:c1",
+                embedding=(),
+                text="gamma",
+                breadcrumb=("C",),
+            ),
+            score=10.0,
+        ),
+    ]
+
+    merged = use_case._merge_hits(vector_hits, lexical_hits)
+
+    assert [hit.record.node_id for hit in merged] == ["b", "a", "c"]
+    assert merged[0].score > merged[1].score > merged[2].score
+
+
+def test_hybrid_search_reports_missing_rank_bm25_dependency(tmp_path, monkeypatch) -> None:
+    import importlib.util
+
+    original_find_spec = importlib.util.find_spec
+
+    def missing_rank_bm25(name: str, package: str | None = None):
+        if name == "rank_bm25":
+            return None
+        return original_find_spec(name, package)
+
+    monkeypatch.setattr(importlib.util, "find_spec", missing_rank_bm25)
+    settings = Settings(index_dir=tmp_path, enable_hybrid_search=True)
+    container = AppContainer(settings=settings)
+
+    errors = container.collect_config_errors()
+
+    assert any("rank-bm25" in error for error in errors)


### PR DESCRIPTION
## Summary
- Erstatter rå score-sammenligning med Reciprocal Rank Fusion (RRF) ved hybrid søk
- Clamper Chroma similarity-score til [0, 1] for forutsigbar `min_score`-filtrering
- Validerer at `rank-bm25` er installert ved oppstart når hybrid er aktivert

## Test plan
- [ ] `uv run pytest tests/test_hybrid_search.py tests/test_chroma_vector_store.py -v`
- [ ] Test hybrid query med `ENABLE_HYBRID_SEARCH=true`
- [ ] Verifiser degraded health når rank-bm25 mangler


Made with [Cursor](https://cursor.com)