### PR TITLE
Run tests only in pre-commit, not in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # Reference workflow for GitHub Actions.
-# Prefer pre-commit locally when Actions is unavailable:
+# Tests and benchmark mock run via pre-commit pre-push hooks locally:
 #   uv run pre-commit install && uv run pre-commit install --hook-type pre-push
 #   bash scripts/ci.sh
 
@@ -12,7 +12,7 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,12 +26,7 @@ jobs:
         run: uv python install 3.11
 
       - name: Install dependencies
-        run: uv sync --python 3.11 --extra dev --extra faiss --extra chroma
-
-      - name: Pre-commit
-        run: |
-          uv run pre-commit run --all-files
-          uv run pre-commit run --all-files --hook-stage pre-push
+        run: uv sync --python 3.11 --extra dev
 
       - name: Ruff check
         run: uv run --python 3.11 --extra dev ruff check .
@@ -41,9 +36,3 @@ jobs:
 
       - name: Import linter
         run: uv run --python 3.11 --extra dev lint-imports
-
-      - name: Pytest
-        run: uv run --python 3.11 --extra dev --extra faiss --extra chroma pytest -m "not live_models" --cov-fail-under=70
-
-      - name: Benchmark mock CLI
-        run: uv run --python 3.11 --extra dev python benchmarks/run_matrix.py --mock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
 
       - id: pytest
         name: pytest (not live_models)
-        entry: uv run --extra dev --extra faiss pytest -m "not live_models"
+        entry: uv run --extra dev --extra faiss --extra chroma pytest -m "not live_models"
         language: system
         pass_filenames: false
         always_run: true


### PR DESCRIPTION
## Summary
- Fjerner pytest, benchmark mock og pre-commit pre-push fra GitHub Actions
- CI kjører kun ruff og import-linter
- Tester forblir på pre-push hooks i pre-commit (som avtalt)

## Test plan
- [ ] Verifiser at GitHub Actions CI er grønn (kun lint)
- [ ] Lokalt: `uv run pre-commit run --all-files --hook-stage pre-push` kjører pytest


Made with [Cursor](https://cursor.com)